### PR TITLE
feat: add analysis toggle configuration

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,11 +17,11 @@ This is a step-by-step plan to build the AIAgent-Orchestrator tool. Complete the
 
 ## Phase 2: Configuration and CLI Entrypoint
 
-- [ ] **`config.py`**: Implement a function to load and parse `config.yml` using `PyYAML`. Ensure it uses `yaml.safe_load()`.
-- [ ] **`config.py`**: Create a data class or dictionary structure to hold the configuration, matching the schema in the design document.
-- [ ] **`cli.py`**: Set up the main Typer application.
-- [ ] **`cli.py`**: Create the main `run` command that will instantiate and start the orchestrator.
-- [ ] **`__main__.py`**: Implement the entry point to call the Typer app from `cli.py`. This allows running the module with `python -m ai_orchestrator`.
+- [x] **`config.py`**: Implement a function to load and parse `config.yml` using `PyYAML`. Ensure it uses `yaml.safe_load()`.
+- [x] **`config.py`**: Create a data class or dictionary structure to hold the configuration, matching the schema in the design document.
+- [x] **`cli.py`**: Set up the main Typer application.
+- [x] **`cli.py`**: Create the main `run` command that will instantiate and start the orchestrator.
+- [x] **`__main__.py`**: Implement the entry point to call the Typer app from `cli.py`. This allows running the module with `python -m ai_orchestrator`.
 
 ## Phase 3: Implement Core Components (Bottom-Up)
 

--- a/aiagent-orchestrator/src/ai_orchestrator/config.py
+++ b/aiagent-orchestrator/src/ai_orchestrator/config.py
@@ -33,6 +33,7 @@ class AnalysisConfig:
 
     provider: str
     model: str
+    enabled: bool = False
 
 
 @dataclass(frozen=True)
@@ -124,13 +125,16 @@ def load_config(path: Path) -> OrchestratorConfig:
 
     provider = analysis_data.get("provider")
     model = analysis_data.get("model")
+    enabled = analysis_data.get("enabled", False)
 
     if not isinstance(provider, str) or not provider.strip():
         raise ValueError("'provider' must be a non-empty string")
     if not isinstance(model, str) or not model.strip():
         raise ValueError("'model' must be a non-empty string")
+    if not isinstance(enabled, bool):
+        raise ValueError("'enabled' must be a boolean value when provided")
 
-    analysis_config = AnalysisConfig(provider=provider, model=model)
+    analysis_config = AnalysisConfig(provider=provider, model=model, enabled=enabled)
 
     return OrchestratorConfig(
         ai_coder=ai_coder_config,


### PR DESCRIPTION
## Summary
- mark the configuration and CLI setup tasks as complete in the project todo list
- extend the analysis configuration to include an enabled flag with validation and a default of disabled

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dd10773df88329bfc2bc4a564b2852