### PR TITLE
fix: log subprocess output

### DIFF
--- a/aiagent-orchestrator/ai_orchestrator.py
+++ b/aiagent-orchestrator/ai_orchestrator.py
@@ -334,6 +334,12 @@ class ProcessManager:
         for line in iter(stream.readline, ""):
             cleaned = line.rstrip("\r\n")
             self._output_queue.put((source, cleaned))
+            # Mirror the subprocess output to the orchestrator logs so that
+            # users can observe the underlying tool's responses in real time.
+            if cleaned:
+                self._logger.info("[%s] %s", source, cleaned)
+            else:
+                self._logger.info("[%s]", source)
         stream.close()
         self._logger.debug("Stream %s closed", source)
 


### PR DESCRIPTION
## Summary
- log each line from the managed subprocess so Codex responses appear in the orchestrator console

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dde00b26ec8329a8fce2e2732260e3