### PR TITLE
fix: add windows conpty support

### DIFF
--- a/aiagent-orchestrator/README.md
+++ b/aiagent-orchestrator/README.md
@@ -100,7 +100,8 @@ analysis:
 Key notes:
 
 - `command` can be either a string or a list of arguments. The loader splits strings with `shlex.split`.
-- `use_pty` enables PTY-based process interaction on POSIX systems. This is required for Codex CLI so keystrokes are delivered correctly. The orchestrator automatically falls back to standard pipes on platforms without PTY support (e.g., Windows).
+- `use_pty` enables PTY-based process interaction on POSIX systems. This is required for Codex CLI so keystrokes are delivered correctly. The orchestrator automatically falls back to standard pipes on platforms without PTY support.
+- On Windows, install `wexpect` and `pywinpty` to enable ConPTY-based interaction. When these packages are available the orchestrator mirrors real keyboard input via a pseudo-terminal; otherwise it logs a fallback message and uses standard pipes.
 - When `analysis.enabled` is `true`, set the `DEEPSEEK_API_KEY` environment variable (or pass `api_key` to `DeepSeekProvider`).
 - When the analysis layer is disabled, the orchestrator assumes the workflow is finished once the completion indicator appears.
 

--- a/aiagent-orchestrator/tests/test_process_manager_windows.py
+++ b/aiagent-orchestrator/tests/test_process_manager_windows.py
@@ -1,0 +1,35 @@
+"""Tests covering Windows-specific behaviour of :mod:`ai_orchestrator`."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+
+import pytest
+
+import ai_orchestrator
+
+
+def test_windows_pty_fallback(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """Ensure PTY mode gracefully falls back when wexpect is unavailable on Windows."""
+
+    monkeypatch.setattr(ai_orchestrator.os, "name", "nt", raising=False)
+    monkeypatch.setattr(ai_orchestrator, "wexpect", None, raising=False)
+
+    caplog.set_level(logging.INFO)
+
+    monkeypatch.setattr(ai_orchestrator.Path, "exists", lambda self: True, raising=False)
+
+    command = [sys.executable, "-c", "import time; time.sleep(0.1)"]
+    manager = ai_orchestrator.ProcessManager(command, use_pty=True)
+
+    try:
+        assert manager._pty_backend is None  # type: ignore[attr-defined]
+        assert not manager._use_pty
+        assert any(
+            "PTY mode requested but not supported" in message for message in caplog.messages
+        )
+    finally:
+        manager.terminate()
+        time.sleep(0.05)


### PR DESCRIPTION
## Summary
- add a wexpect-based PTY backend so Codex-style tools receive keystrokes on Windows
- improve process lifecycle handling for both PTY and pipe communication paths
- document the optional Windows dependencies and cover the fallback path with a regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ddf25adee4832980af740af81323a8