### PR TITLE
fix: remove automatic timeout exit

### DIFF
--- a/aiagent-orchestrator/README.md
+++ b/aiagent-orchestrator/README.md
@@ -84,7 +84,7 @@ ai_coder:
   command: "codex"
   working_indicator: "Esc to interrupt"
   completion_indicator: "此阶段任务已经完成"
-  response_timeout: 180
+  response_timeout: 180  # 设置为 0 或删除该字段即可让编排器无限等待
   use_pty: true
 
 workflow:
@@ -170,13 +170,13 @@ Inspect the generated log file and console output to verify the control loop is 
 ## Troubleshooting
 
 - **Process fails to start** – confirm the command in `ai_coder.command` is available on your PATH. The orchestrator raises `FileNotFoundError` if the executable cannot be launched.
-- **Timeout waiting for completion** – increase `response_timeout` or verify the completion indicator string matches the tool's output exactly.
+- **Long periods with no output** – the orchestrator now waits indefinitely. Adjust `response_timeout` (or remove it) to change how frequently the process is polled for status updates.
 - **DeepSeek analysis errors** – ensure `openai` is installed, `DEEPSEEK_API_KEY` is set, and the configured model is supported.
 
 ## 常见问题排查
 
 - **进程无法启动**：确认 `ai_coder.command` 中的可执行文件已在 PATH 中，否则会抛出 `FileNotFoundError`。
-- **等待完成时超时**：可适当增大 `response_timeout`，或确认完成指示字符串与实际输出完全一致。
+- **长时间无输出**：编排器会持续等待结果，可通过调整或移除 `response_timeout` 来改变状态轮询的频率。
 - **DeepSeek 分析报错**：请确保已安装 `openai` 库，并设置 `DEEPSEEK_API_KEY`，同时检查模型名称是否受支持。
 
 ## License

--- a/aiagent-orchestrator/tests/test_config.py
+++ b/aiagent-orchestrator/tests/test_config.py
@@ -60,3 +60,50 @@ analysis:
 
     with pytest.raises(ValueError):
         load_config(config_path)
+
+
+def test_load_config_allows_disabling_timeout_with_zero(tmp_path: Path) -> None:
+    """Setting ``response_timeout`` to zero should disable the timeout."""
+
+    config_path = tmp_path / DEFAULT_CONFIG_FILENAME
+    config_path.write_text(
+        """\
+ai_coder:
+  command: python -c "print('ready')"
+  completion_indicator: done
+  response_timeout: 0
+workflow:
+  initial_prompt: start
+  continue_prompt: continue
+analysis:
+  enabled: false
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+
+    assert config.ai_coder.response_timeout is None
+
+
+def test_load_config_allows_missing_timeout(tmp_path: Path) -> None:
+    """Omitting ``response_timeout`` should default to no timeout."""
+
+    config_path = tmp_path / DEFAULT_CONFIG_FILENAME
+    config_path.write_text(
+        """\
+ai_coder:
+  command: python -c "print('ready')"
+  completion_indicator: done
+workflow:
+  initial_prompt: start
+  continue_prompt: continue
+analysis:
+  enabled: false
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config(config_path)
+
+    assert config.ai_coder.response_timeout is None


### PR DESCRIPTION
## Summary
- allow the response timeout to be disabled while keeping existing configuration defaults
- change the process manager to poll indefinitely instead of aborting when no output arrives
- document the new behaviour and add regression tests for the optional timeout setting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68de0efc5b008329972ffe452686404e